### PR TITLE
Ensure return value from do_recv

### DIFF
--- a/src/netlinksocket.cc
+++ b/src/netlinksocket.cc
@@ -601,8 +601,11 @@ int NetlinkSocket::do_recvmsg(Request_t* req, SocketMode mode) {
 			nlhdr = (struct nlmsghdr*)((char*)nlhdr + NLMSG_ALIGN(nlmsghdr_length));
 		}
 
-		if(mode == NetlinkTypes::SOCKET_BLOCKING)
+		if(mode == NetlinkTypes::SOCKET_BLOCKING) {
 			return true;
+		} else {
+			return false;
+		}
 	}
 }
 


### PR DESCRIPTION
Make sure to return a value from do_recv as the calling methods execute this in a while loop depending on the return value.  Arm processors do not initialize stack based return values so failures were being caused on arm and not x86.