### PR TITLE
Patch premature socket closing for link inquiries during address commands on busy cpus

### DIFF
--- a/ip/ipparse.js
+++ b/ip/ipparse.js
@@ -162,8 +162,9 @@ var ipparse = {
 	},
 
 	packageInfoLink: function(ch,links) {
-
-		var operstate = ipparse.link_oper_states[ch['operstate'].readUInt8(0)];
+		var opst = ch['operstate'];
+		if(typeof opst === undefined) return {};
+		var operstate = ipparse.link_oper_states[opst.readUInt8(0)];
 		var data = {
 			ifname: ch['ifname'], // the interface name as labeled by the OS
 			ifnum: nativelib.ifNameToIndex(ch['ifname']), // the interface number, as per system call

--- a/ip/link.js
+++ b/ip/link.js
@@ -66,18 +66,19 @@ module.exports.link = function(operation,ifname,cb) {
 	sock.create(sock_opts,function(err) {
 		if(err) {
 			console.log("socket.create() Error: " + util.inspect(err));
-			cb(err);
-			return;
+			sock.close();
+			return cb(err);
 		} else {
 			//console.log("Created netlink socket.");
 
 			netlinkLinkCommand.call(netkitObject,link_opts, sock, function(err,bufs) {
 				if(err) {
-					cb(err);
+					sock.close();
+					return cb(err);
 				} else {
-					cb();
+					sock.close();
+					return cb();
 				}
-				sock.close();
 			});
 		}
 	});


### PR DESCRIPTION
DVJS-314
- Different loop structure for looping on async responses. 
- Move socket closing to happen only after socket send/recv callbacks have been received.
- Removed the undefined error when unsupported wireless link change events are received.