### PR TITLE
DVJS-314: Proxy need to listen IPStack Service - hook when IP changes

### DIFF
--- a/src/netlinksocket.cc
+++ b/src/netlinksocket.cc
@@ -323,7 +323,16 @@ Handle<Value> NetlinkSocket::Sendmsg(const Arguments& args) {
 			if(!sock->listening)
 				post_process_func = &NetlinkSocket::post_recvmsg;
 
-			uv_queue_work(uv_default_loop(), &(req->work), NetlinkSocket::do_sendmsg, post_process_func);
+			// DBG_OUT("uv_backend_fd(uv_default_loop()) = %d", uv_backend_fd(uv_default_loop()));
+			// uv_queue_work(uv_default_loop(), &(req->work), NetlinkSocket::do_sendmsg, post_process_func);
+
+
+			uv_work_t work;
+			memset(&work, 0, sizeof(uv_work_t));
+			work.data = req;
+			do_sendmsg(&work);
+			post_recvmsg(&work,0);
+
 		} else {
 			return ThrowException(Exception::TypeError(String::New("sendMsg() -> bad parameters. Passed in Object is not sockMsgReq.")));
 		}


### PR DESCRIPTION
- hack to execute sendMesg by directly calling do_send and d_recv to avoid the current problem with uv_queue_work not executing worker thread for too long.  This is only possible since the iproute2 subsystem responds very quickly over the netlink interface so the node event loop doesnt block for too long.
- Opened DVJS-379 to track the issue going forward and come up with the real solution.